### PR TITLE
#7:  Retire flat action, vendor flat lib, up Deno 2

### DIFF
--- a/.github/workflows/flat.yml
+++ b/.github/workflows/flat.yml
@@ -13,14 +13,23 @@ jobs:
       contents: write
     steps:
       - name: setup deno
-        uses: denoland/setup-deno@main
+        uses: denoland/setup-deno@v2
         with:
-          deno-version: v1.x
+          deno-version: v2.x
       - name: Check out repo
-        uses: actions/checkout@v4.1.7
-      - name: Fetch data
-        uses: githubocto/flat@v3.4.0
-        with:
-          http_url: https://services1.arcgis.com/UxqqIfhng71wUT9x/arcgis/rest/services/TribalLeadership_Directory/FeatureServer/replicafilescache/TribalLeadership_Directory_-8807089639668789909.csv
-          downloaded_filename: tribal-leaders.csv
-          postprocess: postprocess.ts
+        uses: actions/checkout@v6
+      - name: Download data
+        run: |
+          curl -fsSL -o tribal-leaders.csv \
+            "https://services1.arcgis.com/UxqqIfhng71wUT9x/arcgis/rest/services/TribalLeadership_Directory/FeatureServer/replicafilescache/TribalLeadership_Directory_-8807089639668789909.csv"
+      - name: Run postprocess.ts (clean + sort)
+        run: |
+          deno run --allow-read --allow-write --cached-only \
+            postprocess.ts tribal-leaders.csv
+      - name: Commit updated data
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add tribal-leaders.csv
+          git commit -m "Flat: latest data ($(date -u +%FT%TZ))" || exit 0
+          git push

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,3 @@
+{
+  "vendor": true
+}

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,15 @@
+{
+  "version": "5",
+  "remote": {
+    "https://deno.land/std@0.92.0/_util/assert.ts": "2f868145a042a11d5ad0a3c748dcf580add8a0dbc0e876eaa0026303a5488f58",
+    "https://deno.land/std@0.92.0/bytes/mod.ts": "1ae1ccfe98c4b979f12b015982c7444f81fcb921bea7aa215bf37d84f46e1e13",
+    "https://deno.land/std@0.92.0/encoding/csv.ts": "e01be5287e7aa9c6ff0caf9acf1bc19b8040ef539bfad9089cc366a94e64780d",
+    "https://deno.land/std@0.92.0/encoding/csv_stringify.ts": "f9fe4889f1b2987c8640b4695d2d8836a978d034708ca90a850d3ec6b800d9ba",
+    "https://deno.land/std@0.92.0/io/buffer.ts": "2a92f02c1d8daaebaf13e5678ea5969c89f4fab533f687b9e7e86f49f11c3118",
+    "https://deno.land/std@0.92.0/io/bufio.ts": "4053ea5d978479be68ae4d73424045a59c6b7a6e8f66727e4bfde516baa07126",
+    "https://deno.land/std@0.92.0/io/readers.ts": "17403919724fef2f343c88555606368868a5c752a1099ad801f6a381c170f62d",
+    "https://deno.land/std@0.92.0/io/util.ts": "03ca10e063afce551c501505c607ec336a40b9cb72363f5508e2a9ac81096bbf",
+    "https://deno.land/std@0.92.0/textproto/mod.ts": "1c89b39a079dd158893ab2e9ff79391c66049433d6ca82da7d64b32280570d51",
+    "https://deno.land/x/flat@0.0.15/src/csv.ts": "7b14709fd91a1e0d9153e6ea183df686ca5a6c9b79da317d15cb3efd50fffd9c"
+  }
+}

--- a/postprocess.ts
+++ b/postprocess.ts
@@ -1,5 +1,5 @@
-import { readCSV, writeCSV, removeFile } from 'https://deno.land/x/flat@0.0.15/mod.ts' 
-// replace with latest library as needed: https://deno.land/x/flat@0.0.x/mod.ts
+// Vendored locally via deno.json + vendor/ (re-pin/re-vendor with ./vendor-flat.sh).
+import { readCSV, writeCSV } from 'https://deno.land/x/flat@0.0.15/src/csv.ts'
 
 // flat action runs on Deno, a Node competitor. Flat will pass in the downloaded filename as arg 0.
 const filePath: string = Deno.args[0]

--- a/vendor-flat.sh
+++ b/vendor-flat.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# vendor-flat.sh
+#
+# Helper to vendor the flat library into a local vendor/ folder so the GitHub workflow
+# never downloads it from the internet. This is a one-time operation, but you can re-run 
+# it to update the version.
+#
+# Run it:
+#   ./vendor-flat.sh          # default version (0.0.15)
+#   ./vendor-flat.sh 0.0.16   # or pick a version
+#
+# Then commit: postprocess.ts, deno.json, deno.lock, vendor/
+#
+# Needs deno installed: e.g. brew install deno
+
+set -euo pipefail
+
+# Recommended default
+FLAT_VERSION="${1:-0.0.15}"
+
+# Repo root
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+POSTPROCESS="postprocess.ts"
+DENO_JSON="deno.json"
+
+# preconditions
+if ! command -v deno >/dev/null; then
+  echo "ERROR: deno is not installed. Install it with:" >&2
+  echo "       brew install deno      (or see https://deno.land)" >&2
+  exit 1
+fi
+[ -f "$POSTPROCESS" ] || { echo "ERROR: $POSTPROCESS not found - run from the repo root." >&2; exit 1; }
+
+echo ">> Vendoring flat@${FLAT_VERSION} for ${POSTPROCESS}"
+echo "   $(deno --version | head -1)"
+
+# re-pin the flat version in the imports (portable in-place edit)
+tmp="$(mktemp)"
+sed -E "s#(deno\.land/x/flat@)[0-9]+\.[0-9]+\.[0-9]+#\1${FLAT_VERSION}#g" "$POSTPROCESS" > "$tmp"
+mv "$tmp" "$POSTPROCESS"
+
+# make sure deno.json turns vendoring on
+if [ ! -f "$DENO_JSON" ]; then
+  printf '{\n  "vendor": true\n}\n' > "$DENO_JSON"
+  echo "   created $DENO_JSON  (\"vendor\": true)"
+elif ! grep -q '"vendor"[[:space:]]*:[[:space:]]*true' "$DENO_JSON"; then
+  echo "   WARNING: $DENO_JSON exists but does not set \"vendor\": true - add it, then re-run." >&2
+fi
+
+# vendor the dependency tree + (re)write the lockfile
+rm -rf vendor deno.lock
+deno cache --reload "$POSTPROCESS"
+
+# Verify it runs fully offline
+# Run the same command the workflow uses (--cached-only). If the
+# data file is present we run end-to-end against a backup copy and restore it
+# afterward, so this leaves nothing changed and confirms the new version works.
+SAMPLE="tribal-leaders.csv"
+echo ">> Verifying postprocess.ts runs offline (--cached-only) ..."
+if [ -f "$SAMPLE" ]; then
+  out="$(mktemp)"
+  cp "$SAMPLE" "${SAMPLE}.vendorbak"
+  if deno run --allow-read --allow-write --cached-only "$POSTPROCESS" "$SAMPLE" >"$out" 2>&1; then
+    mv -f "${SAMPLE}.vendorbak" "$SAMPLE"
+    rm -f "$out"
+    echo "   OK - ran end-to-end with no network."
+  else
+    mv -f "${SAMPLE}.vendorbak" "$SAMPLE"
+    echo "   ERROR: offline run failed - vendor/ may be incomplete:" >&2
+    cat "$out" >&2
+    rm -f "$out"
+    exit 1
+  fi
+else
+  deno info "$POSTPROCESS" >/dev/null
+  echo "   OK - dependency graph resolves (no data file to run end-to-end)."
+fi
+
+echo ""
+echo ">> Done. Vendored size:"
+du -sh vendor 2>/dev/null || true
+echo ">> Commit these: $POSTPROCESS  $DENO_JSON  deno.lock  vendor/"

--- a/vendor/deno.land/std@0.92.0/_util/assert.ts
+++ b/vendor/deno.land/std@0.92.0/_util/assert.ts
@@ -1,0 +1,15 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+export class DenoStdInternalError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DenoStdInternalError";
+  }
+}
+
+/** Make an assertion, if not `true`, then throw. */
+export function assert(expr: unknown, msg = ""): asserts expr {
+  if (!expr) {
+    throw new DenoStdInternalError(msg);
+  }
+}

--- a/vendor/deno.land/std@0.92.0/bytes/mod.ts
+++ b/vendor/deno.land/std@0.92.0/bytes/mod.ts
@@ -1,0 +1,190 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+/** Find first index of binary pattern from source. If not found, then return -1
+ * @param source source array
+ * @param pat pattern to find in source array
+ * @param start the index to start looking in the source
+ */
+export function indexOf(
+  source: Uint8Array,
+  pat: Uint8Array,
+  start = 0,
+): number {
+  if (start >= source.length) {
+    return -1;
+  }
+  if (start < 0) {
+    start = 0;
+  }
+  const s = pat[0];
+  for (let i = start; i < source.length; i++) {
+    if (source[i] !== s) continue;
+    const pin = i;
+    let matched = 1;
+    let j = i;
+    while (matched < pat.length) {
+      j++;
+      if (source[j] !== pat[j - pin]) {
+        break;
+      }
+      matched++;
+    }
+    if (matched === pat.length) {
+      return pin;
+    }
+  }
+  return -1;
+}
+
+/** Find last index of binary pattern from source. If not found, then return -1.
+ * @param source source array
+ * @param pat pattern to find in source array
+ * @param start the index to start looking in the source
+ */
+export function lastIndexOf(
+  source: Uint8Array,
+  pat: Uint8Array,
+  start = source.length - 1,
+): number {
+  if (start < 0) {
+    return -1;
+  }
+  if (start >= source.length) {
+    start = source.length - 1;
+  }
+  const e = pat[pat.length - 1];
+  for (let i = start; i >= 0; i--) {
+    if (source[i] !== e) continue;
+    const pin = i;
+    let matched = 1;
+    let j = i;
+    while (matched < pat.length) {
+      j--;
+      if (source[j] !== pat[pat.length - 1 - (pin - j)]) {
+        break;
+      }
+      matched++;
+    }
+    if (matched === pat.length) {
+      return pin - pat.length + 1;
+    }
+  }
+  return -1;
+}
+
+/** Check whether binary arrays are equal to each other.
+ * @param a first array to check equality
+ * @param b second array to check equality
+ */
+export function equals(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < b.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+/** Check whether binary array starts with prefix.
+ * @param source source array
+ * @param prefix prefix array to check in source
+ */
+export function startsWith(source: Uint8Array, prefix: Uint8Array): boolean {
+  for (let i = 0, max = prefix.length; i < max; i++) {
+    if (source[i] !== prefix[i]) return false;
+  }
+  return true;
+}
+
+/** Check whether binary array ends with suffix.
+ * @param source source array
+ * @param suffix suffix array to check in source
+ */
+export function endsWith(source: Uint8Array, suffix: Uint8Array): boolean {
+  for (
+    let srci = source.length - 1, sfxi = suffix.length - 1;
+    sfxi >= 0;
+    srci--, sfxi--
+  ) {
+    if (source[srci] !== suffix[sfxi]) return false;
+  }
+  return true;
+}
+
+/** Repeat bytes. returns a new byte slice consisting of `count` copies of `b`.
+ * @param origin The origin bytes
+ * @param count The count you want to repeat.
+ * @throws `RangeError` When count is negative
+ */
+export function repeat(origin: Uint8Array, count: number): Uint8Array {
+  if (count === 0) {
+    return new Uint8Array();
+  }
+
+  if (count < 0) {
+    throw new RangeError("bytes: negative repeat count");
+  } else if ((origin.length * count) / count !== origin.length) {
+    throw new Error("bytes: repeat count causes overflow");
+  }
+
+  const int = Math.floor(count);
+
+  if (int !== count) {
+    throw new Error("bytes: repeat count must be an integer");
+  }
+
+  const nb = new Uint8Array(origin.length * count);
+
+  let bp = copy(origin, nb);
+
+  for (; bp < nb.length; bp *= 2) {
+    copy(nb.slice(0, bp), nb, bp);
+  }
+
+  return nb;
+}
+
+/** Concatenate multiple binary arrays and return new one.
+ * @param buf binary arrays to concatenate
+ */
+export function concat(...buf: Uint8Array[]): Uint8Array {
+  let length = 0;
+  for (const b of buf) {
+    length += b.length;
+  }
+
+  const output = new Uint8Array(length);
+  let index = 0;
+  for (const b of buf) {
+    output.set(b, index);
+    index += b.length;
+  }
+
+  return output;
+}
+
+/** Check source array contains pattern array.
+ * @param source source array
+ * @param pat patter array
+ */
+export function contains(source: Uint8Array, pat: Uint8Array): boolean {
+  return indexOf(source, pat) != -1;
+}
+
+/**
+ * Copy bytes from one Uint8Array to another.  Bytes from `src` which don't fit
+ * into `dst` will not be copied.
+ *
+ * @param src Source byte array
+ * @param dst Destination byte array
+ * @param off Offset into `dst` at which to begin writing values from `src`.
+ * @return number of bytes copied
+ */
+export function copy(src: Uint8Array, dst: Uint8Array, off = 0): number {
+  off = Math.max(0, Math.min(off, dst.byteLength));
+  const dstBytesAvailable = dst.byteLength - off;
+  if (src.byteLength > dstBytesAvailable) {
+    src = src.subarray(0, dstBytesAvailable);
+  }
+  dst.set(src, off);
+  return src.byteLength;
+}

--- a/vendor/deno.land/std@0.92.0/encoding/csv.ts
+++ b/vendor/deno.land/std@0.92.0/encoding/csv.ts
@@ -1,0 +1,462 @@
+// Ported from Go:
+// https://github.com/golang/go/blob/go1.12.5/src/encoding/csv/
+// Copyright 2011 The Go Authors. All rights reserved. BSD license.
+// https://github.com/golang/go/blob/master/LICENSE
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+
+import { BufReader } from "../io/bufio.ts";
+import { TextProtoReader } from "../textproto/mod.ts";
+import { StringReader } from "../io/readers.ts";
+import { assert } from "../_util/assert.ts";
+
+export { NEWLINE, stringify, StringifyError } from "./csv_stringify.ts";
+
+export type {
+  Column,
+  ColumnDetails,
+  DataItem,
+  StringifyOptions,
+} from "./csv_stringify.ts";
+
+const INVALID_RUNE = ["\r", "\n", '"'];
+
+export const ERR_BARE_QUOTE = 'bare " in non-quoted-field';
+export const ERR_QUOTE = 'extraneous or missing " in quoted-field';
+export const ERR_INVALID_DELIM = "Invalid Delimiter";
+export const ERR_FIELD_COUNT = "wrong number of fields";
+
+/**
+ * A ParseError is returned for parsing errors.
+ * Line numbers are 1-indexed and columns are 0-indexed.
+ */
+export class ParseError extends Error {
+  /** Line where the record starts*/
+  startLine: number;
+  /** Line where the error occurred */
+  line: number;
+  /** Column (rune index) where the error occurred */
+  column: number | null;
+
+  constructor(
+    start: number,
+    line: number,
+    column: number | null,
+    message: string,
+  ) {
+    super();
+    this.startLine = start;
+    this.column = column;
+    this.line = line;
+
+    if (message === ERR_FIELD_COUNT) {
+      this.message = `record on line ${line}: ${message}`;
+    } else if (start !== line) {
+      this.message =
+        `record on line ${start}; parse error on line ${line}, column ${column}: ${message}`;
+    } else {
+      this.message =
+        `parse error on line ${line}, column ${column}: ${message}`;
+    }
+  }
+}
+
+/**
+ * @property separator - Character which separates values. Default: ','
+ * @property comment - Character to start a comment. Default: '#'
+ * @property trimLeadingSpace - Flag to trim the leading space of the value.
+ *           Default: 'false'
+ * @property lazyQuotes - Allow unquoted quote in a quoted field or non double
+ *           quoted quotes in quoted field. Default: 'false'
+ * @property fieldsPerRecord - Enabling the check of fields for each row.
+ *           If == 0, first row is used as referral for the number of fields.
+ */
+export interface ReadOptions {
+  separator?: string;
+  comment?: string;
+  trimLeadingSpace?: boolean;
+  lazyQuotes?: boolean;
+  fieldsPerRecord?: number;
+}
+
+function chkOptions(opt: ReadOptions): void {
+  if (!opt.separator) {
+    opt.separator = ",";
+  }
+  if (!opt.trimLeadingSpace) {
+    opt.trimLeadingSpace = false;
+  }
+  if (
+    INVALID_RUNE.includes(opt.separator) ||
+    (typeof opt.comment === "string" && INVALID_RUNE.includes(opt.comment)) ||
+    opt.separator === opt.comment
+  ) {
+    throw new Error(ERR_INVALID_DELIM);
+  }
+}
+
+async function readRecord(
+  startLine: number,
+  reader: BufReader,
+  opt: ReadOptions = { separator: ",", trimLeadingSpace: false },
+): Promise<string[] | null> {
+  const tp = new TextProtoReader(reader);
+  let line = await readLine(tp);
+  let lineIndex = startLine + 1;
+
+  if (line === null) return null;
+  if (line.length === 0) {
+    return [];
+  }
+  // line starting with comment character is ignored
+  if (opt.comment && line[0] === opt.comment) {
+    return [];
+  }
+
+  assert(opt.separator != null);
+
+  let fullLine = line;
+  let quoteError: ParseError | null = null;
+  const quote = '"';
+  const quoteLen = quote.length;
+  const separatorLen = opt.separator.length;
+  let recordBuffer = "";
+  const fieldIndexes = [] as number[];
+  parseField:
+  for (;;) {
+    if (opt.trimLeadingSpace) {
+      line = line.trimLeft();
+    }
+
+    if (line.length === 0 || !line.startsWith(quote)) {
+      // Non-quoted string field
+      const i = line.indexOf(opt.separator);
+      let field = line;
+      if (i >= 0) {
+        field = field.substring(0, i);
+      }
+      // Check to make sure a quote does not appear in field.
+      if (!opt.lazyQuotes) {
+        const j = field.indexOf(quote);
+        if (j >= 0) {
+          const col = runeCount(
+            fullLine.slice(0, fullLine.length - line.slice(j).length),
+          );
+          quoteError = new ParseError(
+            startLine + 1,
+            lineIndex,
+            col,
+            ERR_BARE_QUOTE,
+          );
+          break parseField;
+        }
+      }
+      recordBuffer += field;
+      fieldIndexes.push(recordBuffer.length);
+      if (i >= 0) {
+        line = line.substring(i + separatorLen);
+        continue parseField;
+      }
+      break parseField;
+    } else {
+      // Quoted string field
+      line = line.substring(quoteLen);
+      for (;;) {
+        const i = line.indexOf(quote);
+        if (i >= 0) {
+          // Hit next quote.
+          recordBuffer += line.substring(0, i);
+          line = line.substring(i + quoteLen);
+          if (line.startsWith(quote)) {
+            // `""` sequence (append quote).
+            recordBuffer += quote;
+            line = line.substring(quoteLen);
+          } else if (line.startsWith(opt.separator)) {
+            // `","` sequence (end of field).
+            line = line.substring(separatorLen);
+            fieldIndexes.push(recordBuffer.length);
+            continue parseField;
+          } else if (0 === line.length) {
+            // `"\n` sequence (end of line).
+            fieldIndexes.push(recordBuffer.length);
+            break parseField;
+          } else if (opt.lazyQuotes) {
+            // `"` sequence (bare quote).
+            recordBuffer += quote;
+          } else {
+            // `"*` sequence (invalid non-escaped quote).
+            const col = runeCount(
+              fullLine.slice(0, fullLine.length - line.length - quoteLen),
+            );
+            quoteError = new ParseError(
+              startLine + 1,
+              lineIndex,
+              col,
+              ERR_QUOTE,
+            );
+            break parseField;
+          }
+        } else if (line.length > 0 || !(await isEOF(tp))) {
+          // Hit end of line (copy all data so far).
+          recordBuffer += line;
+          const r = await readLine(tp);
+          lineIndex++;
+          line = r ?? ""; // This is a workaround for making this module behave similarly to the encoding/csv/reader.go.
+          fullLine = line;
+          if (r === null) {
+            // Abrupt end of file (EOF or error).
+            if (!opt.lazyQuotes) {
+              const col = runeCount(fullLine);
+              quoteError = new ParseError(
+                startLine + 1,
+                lineIndex,
+                col,
+                ERR_QUOTE,
+              );
+              break parseField;
+            }
+            fieldIndexes.push(recordBuffer.length);
+            break parseField;
+          }
+          recordBuffer += "\n"; // preserve line feed (This is because TextProtoReader removes it.)
+        } else {
+          // Abrupt end of file (EOF on error).
+          if (!opt.lazyQuotes) {
+            const col = runeCount(fullLine);
+            quoteError = new ParseError(
+              startLine + 1,
+              lineIndex,
+              col,
+              ERR_QUOTE,
+            );
+            break parseField;
+          }
+          fieldIndexes.push(recordBuffer.length);
+          break parseField;
+        }
+      }
+    }
+  }
+  if (quoteError) {
+    throw quoteError;
+  }
+  const result = [] as string[];
+  let preIdx = 0;
+  for (const i of fieldIndexes) {
+    result.push(recordBuffer.slice(preIdx, i));
+    preIdx = i;
+  }
+  return result;
+}
+
+async function isEOF(tp: TextProtoReader): Promise<boolean> {
+  return (await tp.r.peek(0)) === null;
+}
+
+function runeCount(s: string): number {
+  // Array.from considers the surrogate pair.
+  return Array.from(s).length;
+}
+
+async function readLine(tp: TextProtoReader): Promise<string | null> {
+  let line: string;
+  const r = await tp.readLine();
+  if (r === null) return null;
+  line = r;
+
+  // For backwards compatibility, drop trailing \r before EOF.
+  if ((await isEOF(tp)) && line.length > 0 && line[line.length - 1] === "\r") {
+    line = line.substring(0, line.length - 1);
+  }
+
+  // Normalize \r\n to \n on all input lines.
+  if (
+    line.length >= 2 &&
+    line[line.length - 2] === "\r" &&
+    line[line.length - 1] === "\n"
+  ) {
+    line = line.substring(0, line.length - 2);
+    line = line + "\n";
+  }
+
+  return line;
+}
+
+/**
+ * Parse the CSV from the `reader` with the options provided and return `string[][]`.
+ *
+ * @param reader provides the CSV data to parse
+ * @param opt controls the parsing behavior
+ */
+export async function readMatrix(
+  reader: BufReader,
+  opt: ReadOptions = {
+    separator: ",",
+    trimLeadingSpace: false,
+    lazyQuotes: false,
+  },
+): Promise<string[][]> {
+  const result: string[][] = [];
+  let _nbFields: number | undefined;
+  let lineResult: string[];
+  let first = true;
+  let lineIndex = 0;
+  chkOptions(opt);
+
+  for (;;) {
+    const r = await readRecord(lineIndex, reader, opt);
+    if (r === null) break;
+    lineResult = r;
+    lineIndex++;
+    // If fieldsPerRecord is 0, Read sets it to
+    // the number of fields in the first record
+    if (first) {
+      first = false;
+      if (opt.fieldsPerRecord !== undefined) {
+        if (opt.fieldsPerRecord === 0) {
+          _nbFields = lineResult.length;
+        } else {
+          _nbFields = opt.fieldsPerRecord;
+        }
+      }
+    }
+
+    if (lineResult.length > 0) {
+      if (_nbFields && _nbFields !== lineResult.length) {
+        throw new ParseError(lineIndex, lineIndex, null, ERR_FIELD_COUNT);
+      }
+      result.push(lineResult);
+    }
+  }
+  return result;
+}
+
+/**
+ * Parse the CSV string/buffer with the options provided.
+ *
+ * ColumnOptions provides the column definition
+ * and the parse function for each entry of the
+ * column.
+ */
+export interface ColumnOptions {
+  /**
+   * Name of the column to be used as property
+   */
+  name: string;
+  /**
+   * Parse function for the column.
+   * This is executed on each entry of the header.
+   * This can be combined with the Parse function of the rows.
+   */
+  parse?: (input: string) => unknown;
+}
+
+export interface ParseOptions extends ReadOptions {
+  /**
+   * If you provide `skipFirstRow: true` and `columns`, the first line will be skipped.
+   * If you provide `skipFirstRow: true` but not `columns`, the first line will be skipped and used as header definitions.
+   */
+  skipFirstRow?: boolean;
+
+  /**
+   * If you provide `string[]` or `ColumnOptions[]`, those names will be used for header definition.
+   */
+  columns?: string[] | ColumnOptions[];
+
+  /** Parse function for rows.
+   * Example:
+   *     const r = await parseFile('a,b,c\ne,f,g\n', {
+   *      columns: ["this", "is", "sparta"],
+   *       parse: (e: Record<string, unknown>) => {
+   *         return { super: e.this, street: e.is, fighter: e.sparta };
+   *       }
+   *     });
+   * // output
+   * [
+   *   { super: "a", street: "b", fighter: "c" },
+   *   { super: "e", street: "f", fighter: "g" }
+   * ]
+   */
+  parse?: (input: unknown) => unknown;
+}
+
+/**
+ * Csv parse helper to manipulate data.
+ * Provides an auto/custom mapper for columns and parse function
+ * for columns and rows.
+ * @param input Input to parse. Can be a string or BufReader.
+ * @param opt options of the parser.
+ * @returns If you don't provide `opt.skipFirstRow`, `opt.parse`, and `opt.columns`, it returns `string[][]`.
+ *   If you provide `opt.skipFirstRow` or `opt.columns` but not `opt.parse`, it returns `object[]`.
+ *   If you provide `opt.parse`, it returns an array where each element is the value returned from `opt.parse`.
+ */
+export async function parse(
+  input: string | BufReader,
+  opt: ParseOptions = {
+    skipFirstRow: false,
+  },
+): Promise<unknown[]> {
+  let r: string[][];
+  if (input instanceof BufReader) {
+    r = await readMatrix(input, opt);
+  } else {
+    r = await readMatrix(new BufReader(new StringReader(input)), opt);
+  }
+  if (opt.skipFirstRow || opt.columns) {
+    let headers: ColumnOptions[] = [];
+    let i = 0;
+
+    if (opt.skipFirstRow) {
+      const head = r.shift();
+      assert(head != null);
+      headers = head.map(
+        (e): ColumnOptions => {
+          return {
+            name: e,
+          };
+        },
+      );
+      i++;
+    }
+
+    if (opt.columns) {
+      if (typeof opt.columns[0] !== "string") {
+        headers = opt.columns as ColumnOptions[];
+      } else {
+        const h = opt.columns as string[];
+        headers = h.map(
+          (e): ColumnOptions => {
+            return {
+              name: e,
+            };
+          },
+        );
+      }
+    }
+    return r.map((e): unknown => {
+      if (e.length !== headers.length) {
+        throw `Error number of fields line:${i}`;
+      }
+      i++;
+      const out: Record<string, unknown> = {};
+      for (let j = 0; j < e.length; j++) {
+        const h = headers[j];
+        if (h.parse) {
+          out[h.name] = h.parse(e[j]);
+        } else {
+          out[h.name] = e[j];
+        }
+      }
+      if (opt.parse) {
+        return opt.parse(out);
+      }
+      return out;
+    });
+  }
+  if (opt.parse) {
+    return r.map((e: string[]): unknown => {
+      assert(opt.parse, "opt.parse must be set");
+      return opt.parse(e);
+    });
+  }
+  return r;
+}

--- a/vendor/deno.land/std@0.92.0/encoding/csv_stringify.ts
+++ b/vendor/deno.land/std@0.92.0/encoding/csv_stringify.ts
@@ -1,0 +1,172 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+// Implements the CSV spec at https://tools.ietf.org/html/rfc4180
+
+// This module is browser compatible.
+
+const QUOTE = '"';
+export const NEWLINE = "\r\n";
+
+export class StringifyError extends Error {
+  readonly name = "StringifyError";
+}
+
+function getEscapedString(value: unknown, sep: string): string {
+  if (value === undefined || value === null) return "";
+  let str = "";
+
+  if (typeof value === "object") str = JSON.stringify(value);
+  else str = String(value);
+
+  // Is regex.test more performant here? If so, how to dynamically create?
+  // https://stackoverflow.com/questions/3561493/
+  if (str.includes(sep) || str.includes(NEWLINE) || str.includes(QUOTE)) {
+    return `${QUOTE}${str.replaceAll(QUOTE, `${QUOTE}${QUOTE}`)}${QUOTE}`;
+  }
+
+  return str;
+}
+
+type PropertyAccessor = number | string;
+
+/**
+ * @param fn Optional callback for transforming the value
+ *
+ * @param header Explicit column header name. If omitted,
+ * the (final) property accessor is used for this value.
+ *
+ * @param prop Property accessor(s) used to access the value on the object
+ */
+export type ColumnDetails = {
+  // "unknown" is more type-safe, but inconvenient for user. How to resolve?
+  // deno-lint-ignore no-explicit-any
+  fn?: (value: any) => string | Promise<string>;
+  header?: string;
+  prop: PropertyAccessor | PropertyAccessor[];
+};
+
+export type Column = ColumnDetails | PropertyAccessor | PropertyAccessor[];
+
+type NormalizedColumn = Omit<ColumnDetails, "header" | "prop"> & {
+  header: string;
+  prop: PropertyAccessor[];
+};
+
+function normalizeColumn(column: Column): NormalizedColumn {
+  let fn: NormalizedColumn["fn"],
+    header: NormalizedColumn["header"],
+    prop: NormalizedColumn["prop"];
+
+  if (typeof column === "object") {
+    if (Array.isArray(column)) {
+      header = String(column[column.length - 1]);
+      prop = column;
+    } else {
+      ({ fn } = column);
+      prop = Array.isArray(column.prop) ? column.prop : [column.prop];
+      header = typeof column.header === "string"
+        ? column.header
+        : String(prop[prop.length - 1]);
+    }
+  } else {
+    header = String(column);
+    prop = [column];
+  }
+
+  return { fn, header, prop };
+}
+
+type ObjectWithStringPropertyKeys = Record<string, unknown>;
+
+/** An object (plain or array) */
+export type DataItem = ObjectWithStringPropertyKeys | unknown[];
+
+/**
+ * Returns an array of values from an object using the property accessors
+ * (and optional transform function) in each column
+ */
+async function getValuesFromItem(
+  item: DataItem,
+  normalizedColumns: NormalizedColumn[],
+): Promise<unknown[]> {
+  const values: unknown[] = [];
+
+  for (const column of normalizedColumns) {
+    let value: unknown = item;
+
+    for (const prop of column.prop) {
+      if (typeof value !== "object" || value === null) continue;
+      if (Array.isArray(value)) {
+        if (typeof prop === "number") value = value[prop];
+        else {
+          throw new StringifyError('Property accessor is not of type "number"');
+        }
+      } // I think this assertion is safe. Confirm?
+      else value = (value as ObjectWithStringPropertyKeys)[prop];
+    }
+
+    if (typeof column.fn === "function") value = await column.fn(value);
+    values.push(value);
+  }
+
+  return values;
+}
+
+/**
+ * @param headers Whether or not to include the row of headers.
+ * Default: `true`
+ *
+ * @param separator Delimiter used to separate values. Examples:
+ *  - `","` _comma_ (Default)
+ *  - `"\t"` _tab_
+ *  - `"|"` _pipe_
+ *  - etc.
+ */
+export type StringifyOptions = {
+  headers?: boolean;
+  separator?: string;
+};
+
+/**
+ * @param data The array of objects to encode
+ * @param columns Array of values specifying which data to include in the output
+ * @param options Output formatting options
+ */
+export async function stringify(
+  data: DataItem[],
+  columns: Column[],
+  options: StringifyOptions = {},
+): Promise<string> {
+  const { headers, separator: sep } = {
+    headers: true,
+    separator: ",",
+    ...options,
+  };
+  if (sep.includes(QUOTE) || sep.includes(NEWLINE)) {
+    const message = [
+      "Separator cannot include the following strings:",
+      '  - U+0022: Quotation mark (")',
+      "  - U+000D U+000A: Carriage Return + Line Feed (\\r\\n)",
+    ].join("\n");
+    throw new StringifyError(message);
+  }
+
+  const normalizedColumns = columns.map(normalizeColumn);
+  let output = "";
+
+  if (headers) {
+    output += normalizedColumns
+      .map((column) => getEscapedString(column.header, sep))
+      .join(sep);
+    output += NEWLINE;
+  }
+
+  for (const item of data) {
+    const values = await getValuesFromItem(item, normalizedColumns);
+    output += values
+      .map((value) => getEscapedString(value, sep))
+      .join(sep);
+    output += NEWLINE;
+  }
+
+  return output;
+}

--- a/vendor/deno.land/std@0.92.0/io/buffer.ts
+++ b/vendor/deno.land/std@0.92.0/io/buffer.ts
@@ -1,0 +1,260 @@
+import { assert } from "../_util/assert.ts";
+
+// MIN_READ is the minimum ArrayBuffer size passed to a read call by
+// buffer.ReadFrom. As long as the Buffer has at least MIN_READ bytes beyond
+// what is required to hold the contents of r, readFrom() will not grow the
+// underlying buffer.
+const MIN_READ = 32 * 1024;
+const MAX_SIZE = 2 ** 32 - 2;
+
+// `off` is the offset into `dst` where it will at which to begin writing values
+// from `src`.
+// Returns the number of bytes copied.
+function copyBytes(src: Uint8Array, dst: Uint8Array, off = 0) {
+  const r = dst.byteLength - off;
+  if (src.byteLength > r) {
+    src = src.subarray(0, r);
+  }
+  dst.set(src, off);
+  return src.byteLength;
+}
+
+/** A variable-sized buffer of bytes with `read()` and `write()` methods.
+ *
+ * Buffer is almost always used with some I/O like files and sockets. It allows
+ * one to buffer up a download from a socket. Buffer grows and shrinks as
+ * necessary.
+ *
+ * Buffer is NOT the same thing as Node's Buffer. Node's Buffer was created in
+ * 2009 before JavaScript had the concept of ArrayBuffers. It's simply a
+ * non-standard ArrayBuffer.
+ *
+ * ArrayBuffer is a fixed memory allocation. Buffer is implemented on top of
+ * ArrayBuffer.
+ *
+ * Based on [Go Buffer](https://golang.org/pkg/bytes/#Buffer). */
+
+export class Buffer {
+  #buf: Uint8Array; // contents are the bytes buf[off : len(buf)]
+  #off = 0; // read at buf[off], write at buf[buf.byteLength]
+
+  constructor(ab?: ArrayBuffer) {
+    if (ab === undefined) {
+      this.#buf = new Uint8Array(0);
+      return;
+    }
+    this.#buf = new Uint8Array(ab);
+  }
+
+  /** Returns a slice holding the unread portion of the buffer.
+   *
+   * The slice is valid for use only until the next buffer modification (that
+   * is, only until the next call to a method like `read()`, `write()`,
+   * `reset()`, or `truncate()`). If `options.copy` is false the slice aliases the buffer content at
+   * least until the next buffer modification, so immediate changes to the
+   * slice will affect the result of future reads.
+   * @param options Defaults to `{ copy: true }`
+   */
+  bytes(options = { copy: true }): Uint8Array {
+    if (options.copy === false) return this.#buf.subarray(this.#off);
+    return this.#buf.slice(this.#off);
+  }
+
+  /** Returns whether the unread portion of the buffer is empty. */
+  empty(): boolean {
+    return this.#buf.byteLength <= this.#off;
+  }
+
+  /** A read only number of bytes of the unread portion of the buffer. */
+  get length(): number {
+    return this.#buf.byteLength - this.#off;
+  }
+
+  /** The read only capacity of the buffer's underlying byte slice, that is,
+   * the total space allocated for the buffer's data. */
+  get capacity(): number {
+    return this.#buf.buffer.byteLength;
+  }
+
+  /** Discards all but the first `n` unread bytes from the buffer but
+   * continues to use the same allocated storage. It throws if `n` is
+   * negative or greater than the length of the buffer. */
+  truncate(n: number): void {
+    if (n === 0) {
+      this.reset();
+      return;
+    }
+    if (n < 0 || n > this.length) {
+      throw Error("bytes.Buffer: truncation out of range");
+    }
+    this.#reslice(this.#off + n);
+  }
+
+  reset(): void {
+    this.#reslice(0);
+    this.#off = 0;
+  }
+
+  #tryGrowByReslice = (n: number) => {
+    const l = this.#buf.byteLength;
+    if (n <= this.capacity - l) {
+      this.#reslice(l + n);
+      return l;
+    }
+    return -1;
+  };
+
+  #reslice = (len: number) => {
+    assert(len <= this.#buf.buffer.byteLength);
+    this.#buf = new Uint8Array(this.#buf.buffer, 0, len);
+  };
+
+  /** Reads the next `p.length` bytes from the buffer or until the buffer is
+   * drained. Returns the number of bytes read. If the buffer has no data to
+   * return, the return is EOF (`null`). */
+  readSync(p: Uint8Array): number | null {
+    if (this.empty()) {
+      // Buffer is empty, reset to recover space.
+      this.reset();
+      if (p.byteLength === 0) {
+        // this edge case is tested in 'bufferReadEmptyAtEOF' test
+        return 0;
+      }
+      return null;
+    }
+    const nread = copyBytes(this.#buf.subarray(this.#off), p);
+    this.#off += nread;
+    return nread;
+  }
+
+  /** Reads the next `p.length` bytes from the buffer or until the buffer is
+   * drained. Resolves to the number of bytes read. If the buffer has no
+   * data to return, resolves to EOF (`null`).
+   *
+   * NOTE: This methods reads bytes synchronously; it's provided for
+   * compatibility with `Reader` interfaces.
+   */
+  read(p: Uint8Array): Promise<number | null> {
+    const rr = this.readSync(p);
+    return Promise.resolve(rr);
+  }
+
+  writeSync(p: Uint8Array): number {
+    const m = this.#grow(p.byteLength);
+    return copyBytes(p, this.#buf, m);
+  }
+
+  /** NOTE: This methods writes bytes synchronously; it's provided for
+   * compatibility with `Writer` interface. */
+  write(p: Uint8Array): Promise<number> {
+    const n = this.writeSync(p);
+    return Promise.resolve(n);
+  }
+
+  #grow = (n: number) => {
+    const m = this.length;
+    // If buffer is empty, reset to recover space.
+    if (m === 0 && this.#off !== 0) {
+      this.reset();
+    }
+    // Fast: Try to grow by means of a reslice.
+    const i = this.#tryGrowByReslice(n);
+    if (i >= 0) {
+      return i;
+    }
+    const c = this.capacity;
+    if (n <= Math.floor(c / 2) - m) {
+      // We can slide things down instead of allocating a new
+      // ArrayBuffer. We only need m+n <= c to slide, but
+      // we instead let capacity get twice as large so we
+      // don't spend all our time copying.
+      copyBytes(this.#buf.subarray(this.#off), this.#buf);
+    } else if (c + n > MAX_SIZE) {
+      throw new Error("The buffer cannot be grown beyond the maximum size.");
+    } else {
+      // Not enough space anywhere, we need to allocate.
+      const buf = new Uint8Array(Math.min(2 * c + n, MAX_SIZE));
+      copyBytes(this.#buf.subarray(this.#off), buf);
+      this.#buf = buf;
+    }
+    // Restore this.#off and len(this.#buf).
+    this.#off = 0;
+    this.#reslice(Math.min(m + n, MAX_SIZE));
+    return m;
+  };
+
+  /** Grows the buffer's capacity, if necessary, to guarantee space for
+   * another `n` bytes. After `.grow(n)`, at least `n` bytes can be written to
+   * the buffer without another allocation. If `n` is negative, `.grow()` will
+   * throw. If the buffer can't grow it will throw an error.
+   *
+   * Based on Go Lang's
+   * [Buffer.Grow](https://golang.org/pkg/bytes/#Buffer.Grow). */
+  grow(n: number): void {
+    if (n < 0) {
+      throw Error("Buffer.grow: negative count");
+    }
+    const m = this.#grow(n);
+    this.#reslice(m);
+  }
+
+  /** Reads data from `r` until EOF (`null`) and appends it to the buffer,
+   * growing the buffer as needed. It resolves to the number of bytes read.
+   * If the buffer becomes too large, `.readFrom()` will reject with an error.
+   *
+   * Based on Go Lang's
+   * [Buffer.ReadFrom](https://golang.org/pkg/bytes/#Buffer.ReadFrom). */
+  async readFrom(r: Deno.Reader): Promise<number> {
+    let n = 0;
+    const tmp = new Uint8Array(MIN_READ);
+    while (true) {
+      const shouldGrow = this.capacity - this.length < MIN_READ;
+      // read into tmp buffer if there's not enough room
+      // otherwise read directly into the internal buffer
+      const buf = shouldGrow
+        ? tmp
+        : new Uint8Array(this.#buf.buffer, this.length);
+
+      const nread = await r.read(buf);
+      if (nread === null) {
+        return n;
+      }
+
+      // write will grow if needed
+      if (shouldGrow) this.writeSync(buf.subarray(0, nread));
+      else this.#reslice(this.length + nread);
+
+      n += nread;
+    }
+  }
+
+  /** Reads data from `r` until EOF (`null`) and appends it to the buffer,
+   * growing the buffer as needed. It returns the number of bytes read. If the
+   * buffer becomes too large, `.readFromSync()` will throw an error.
+   *
+   * Based on Go Lang's
+   * [Buffer.ReadFrom](https://golang.org/pkg/bytes/#Buffer.ReadFrom). */
+  readFromSync(r: Deno.ReaderSync): number {
+    let n = 0;
+    const tmp = new Uint8Array(MIN_READ);
+    while (true) {
+      const shouldGrow = this.capacity - this.length < MIN_READ;
+      // read into tmp buffer if there's not enough room
+      // otherwise read directly into the internal buffer
+      const buf = shouldGrow
+        ? tmp
+        : new Uint8Array(this.#buf.buffer, this.length);
+
+      const nread = r.readSync(buf);
+      if (nread === null) {
+        return n;
+      }
+
+      // write will grow if needed
+      if (shouldGrow) this.writeSync(buf.subarray(0, nread));
+      else this.#reslice(this.length + nread);
+
+      n += nread;
+    }
+  }
+}

--- a/vendor/deno.land/std@0.92.0/io/bufio.ts
+++ b/vendor/deno.land/std@0.92.0/io/bufio.ts
@@ -1,0 +1,720 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+// Based on https://github.com/golang/go/blob/891682/src/bufio/bufio.go
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+type Reader = Deno.Reader;
+type Writer = Deno.Writer;
+type WriterSync = Deno.WriterSync;
+import { copy } from "../bytes/mod.ts";
+import { assert } from "../_util/assert.ts";
+import { Buffer } from "./buffer.ts";
+import { writeAll, writeAllSync } from "./util.ts";
+
+const DEFAULT_BUF_SIZE = 4096;
+const MIN_BUF_SIZE = 16;
+const MAX_CONSECUTIVE_EMPTY_READS = 100;
+const CR = "\r".charCodeAt(0);
+const LF = "\n".charCodeAt(0);
+
+export class BufferFullError extends Error {
+  name = "BufferFullError";
+  constructor(public partial: Uint8Array) {
+    super("Buffer full");
+  }
+}
+
+export class PartialReadError extends Error {
+  name = "PartialReadError";
+  partial?: Uint8Array;
+  constructor() {
+    super("Encountered UnexpectedEof, data only partially read");
+  }
+}
+
+/** Result type returned by of BufReader.readLine(). */
+export interface ReadLineResult {
+  line: Uint8Array;
+  more: boolean;
+}
+
+/** BufReader implements buffering for a Reader object. */
+export class BufReader implements Reader {
+  private buf!: Uint8Array;
+  private rd!: Reader; // Reader provided by caller.
+  private r = 0; // buf read position.
+  private w = 0; // buf write position.
+  private eof = false;
+  // private lastByte: number;
+  // private lastCharSize: number;
+
+  /** return new BufReader unless r is BufReader */
+  static create(r: Reader, size: number = DEFAULT_BUF_SIZE): BufReader {
+    return r instanceof BufReader ? r : new BufReader(r, size);
+  }
+
+  constructor(rd: Reader, size: number = DEFAULT_BUF_SIZE) {
+    if (size < MIN_BUF_SIZE) {
+      size = MIN_BUF_SIZE;
+    }
+    this._reset(new Uint8Array(size), rd);
+  }
+
+  /** Returns the size of the underlying buffer in bytes. */
+  size(): number {
+    return this.buf.byteLength;
+  }
+
+  buffered(): number {
+    return this.w - this.r;
+  }
+
+  // Reads a new chunk into the buffer.
+  private async _fill(): Promise<void> {
+    // Slide existing data to beginning.
+    if (this.r > 0) {
+      this.buf.copyWithin(0, this.r, this.w);
+      this.w -= this.r;
+      this.r = 0;
+    }
+
+    if (this.w >= this.buf.byteLength) {
+      throw Error("bufio: tried to fill full buffer");
+    }
+
+    // Read new data: try a limited number of times.
+    for (let i = MAX_CONSECUTIVE_EMPTY_READS; i > 0; i--) {
+      const rr = await this.rd.read(this.buf.subarray(this.w));
+      if (rr === null) {
+        this.eof = true;
+        return;
+      }
+      assert(rr >= 0, "negative read");
+      this.w += rr;
+      if (rr > 0) {
+        return;
+      }
+    }
+
+    throw new Error(
+      `No progress after ${MAX_CONSECUTIVE_EMPTY_READS} read() calls`,
+    );
+  }
+
+  /** Discards any buffered data, resets all state, and switches
+   * the buffered reader to read from r.
+   */
+  reset(r: Reader): void {
+    this._reset(this.buf, r);
+  }
+
+  private _reset(buf: Uint8Array, rd: Reader): void {
+    this.buf = buf;
+    this.rd = rd;
+    this.eof = false;
+    // this.lastByte = -1;
+    // this.lastCharSize = -1;
+  }
+
+  /** reads data into p.
+   * It returns the number of bytes read into p.
+   * The bytes are taken from at most one Read on the underlying Reader,
+   * hence n may be less than len(p).
+   * To read exactly len(p) bytes, use io.ReadFull(b, p).
+   */
+  async read(p: Uint8Array): Promise<number | null> {
+    let rr: number | null = p.byteLength;
+    if (p.byteLength === 0) return rr;
+
+    if (this.r === this.w) {
+      if (p.byteLength >= this.buf.byteLength) {
+        // Large read, empty buffer.
+        // Read directly into p to avoid copy.
+        const rr = await this.rd.read(p);
+        const nread = rr ?? 0;
+        assert(nread >= 0, "negative read");
+        // if (rr.nread > 0) {
+        //   this.lastByte = p[rr.nread - 1];
+        //   this.lastCharSize = -1;
+        // }
+        return rr;
+      }
+
+      // One read.
+      // Do not use this.fill, which will loop.
+      this.r = 0;
+      this.w = 0;
+      rr = await this.rd.read(this.buf);
+      if (rr === 0 || rr === null) return rr;
+      assert(rr >= 0, "negative read");
+      this.w += rr;
+    }
+
+    // copy as much as we can
+    const copied = copy(this.buf.subarray(this.r, this.w), p, 0);
+    this.r += copied;
+    // this.lastByte = this.buf[this.r - 1];
+    // this.lastCharSize = -1;
+    return copied;
+  }
+
+  /** reads exactly `p.length` bytes into `p`.
+   *
+   * If successful, `p` is returned.
+   *
+   * If the end of the underlying stream has been reached, and there are no more
+   * bytes available in the buffer, `readFull()` returns `null` instead.
+   *
+   * An error is thrown if some bytes could be read, but not enough to fill `p`
+   * entirely before the underlying stream reported an error or EOF. Any error
+   * thrown will have a `partial` property that indicates the slice of the
+   * buffer that has been successfully filled with data.
+   *
+   * Ported from https://golang.org/pkg/io/#ReadFull
+   */
+  async readFull(p: Uint8Array): Promise<Uint8Array | null> {
+    let bytesRead = 0;
+    while (bytesRead < p.length) {
+      try {
+        const rr = await this.read(p.subarray(bytesRead));
+        if (rr === null) {
+          if (bytesRead === 0) {
+            return null;
+          } else {
+            throw new PartialReadError();
+          }
+        }
+        bytesRead += rr;
+      } catch (err) {
+        err.partial = p.subarray(0, bytesRead);
+        throw err;
+      }
+    }
+    return p;
+  }
+
+  /** Returns the next byte [0, 255] or `null`. */
+  async readByte(): Promise<number | null> {
+    while (this.r === this.w) {
+      if (this.eof) return null;
+      await this._fill(); // buffer is empty.
+    }
+    const c = this.buf[this.r];
+    this.r++;
+    // this.lastByte = c;
+    return c;
+  }
+
+  /** readString() reads until the first occurrence of delim in the input,
+   * returning a string containing the data up to and including the delimiter.
+   * If ReadString encounters an error before finding a delimiter,
+   * it returns the data read before the error and the error itself
+   * (often `null`).
+   * ReadString returns err != nil if and only if the returned data does not end
+   * in delim.
+   * For simple uses, a Scanner may be more convenient.
+   */
+  async readString(delim: string): Promise<string | null> {
+    if (delim.length !== 1) {
+      throw new Error("Delimiter should be a single character");
+    }
+    const buffer = await this.readSlice(delim.charCodeAt(0));
+    if (buffer === null) return null;
+    return new TextDecoder().decode(buffer);
+  }
+
+  /** `readLine()` is a low-level line-reading primitive. Most callers should
+   * use `readString('\n')` instead or use a Scanner.
+   *
+   * `readLine()` tries to return a single line, not including the end-of-line
+   * bytes. If the line was too long for the buffer then `more` is set and the
+   * beginning of the line is returned. The rest of the line will be returned
+   * from future calls. `more` will be false when returning the last fragment
+   * of the line. The returned buffer is only valid until the next call to
+   * `readLine()`.
+   *
+   * The text returned from ReadLine does not include the line end ("\r\n" or
+   * "\n").
+   *
+   * When the end of the underlying stream is reached, the final bytes in the
+   * stream are returned. No indication or error is given if the input ends
+   * without a final line end. When there are no more trailing bytes to read,
+   * `readLine()` returns `null`.
+   *
+   * Calling `unreadByte()` after `readLine()` will always unread the last byte
+   * read (possibly a character belonging to the line end) even if that byte is
+   * not part of the line returned by `readLine()`.
+   */
+  async readLine(): Promise<ReadLineResult | null> {
+    let line: Uint8Array | null;
+
+    try {
+      line = await this.readSlice(LF);
+    } catch (err) {
+      let { partial } = err;
+      assert(
+        partial instanceof Uint8Array,
+        "bufio: caught error from `readSlice()` without `partial` property",
+      );
+
+      // Don't throw if `readSlice()` failed with `BufferFullError`, instead we
+      // just return whatever is available and set the `more` flag.
+      if (!(err instanceof BufferFullError)) {
+        throw err;
+      }
+
+      // Handle the case where "\r\n" straddles the buffer.
+      if (
+        !this.eof &&
+        partial.byteLength > 0 &&
+        partial[partial.byteLength - 1] === CR
+      ) {
+        // Put the '\r' back on buf and drop it from line.
+        // Let the next call to ReadLine check for "\r\n".
+        assert(this.r > 0, "bufio: tried to rewind past start of buffer");
+        this.r--;
+        partial = partial.subarray(0, partial.byteLength - 1);
+      }
+
+      return { line: partial, more: !this.eof };
+    }
+
+    if (line === null) {
+      return null;
+    }
+
+    if (line.byteLength === 0) {
+      return { line, more: false };
+    }
+
+    if (line[line.byteLength - 1] == LF) {
+      let drop = 1;
+      if (line.byteLength > 1 && line[line.byteLength - 2] === CR) {
+        drop = 2;
+      }
+      line = line.subarray(0, line.byteLength - drop);
+    }
+    return { line, more: false };
+  }
+
+  /** `readSlice()` reads until the first occurrence of `delim` in the input,
+   * returning a slice pointing at the bytes in the buffer. The bytes stop
+   * being valid at the next read.
+   *
+   * If `readSlice()` encounters an error before finding a delimiter, or the
+   * buffer fills without finding a delimiter, it throws an error with a
+   * `partial` property that contains the entire buffer.
+   *
+   * If `readSlice()` encounters the end of the underlying stream and there are
+   * any bytes left in the buffer, the rest of the buffer is returned. In other
+   * words, EOF is always treated as a delimiter. Once the buffer is empty,
+   * it returns `null`.
+   *
+   * Because the data returned from `readSlice()` will be overwritten by the
+   * next I/O operation, most clients should use `readString()` instead.
+   */
+  async readSlice(delim: number): Promise<Uint8Array | null> {
+    let s = 0; // search start index
+    let slice: Uint8Array | undefined;
+
+    while (true) {
+      // Search buffer.
+      let i = this.buf.subarray(this.r + s, this.w).indexOf(delim);
+      if (i >= 0) {
+        i += s;
+        slice = this.buf.subarray(this.r, this.r + i + 1);
+        this.r += i + 1;
+        break;
+      }
+
+      // EOF?
+      if (this.eof) {
+        if (this.r === this.w) {
+          return null;
+        }
+        slice = this.buf.subarray(this.r, this.w);
+        this.r = this.w;
+        break;
+      }
+
+      // Buffer full?
+      if (this.buffered() >= this.buf.byteLength) {
+        this.r = this.w;
+        // #4521 The internal buffer should not be reused across reads because it causes corruption of data.
+        const oldbuf = this.buf;
+        const newbuf = this.buf.slice(0);
+        this.buf = newbuf;
+        throw new BufferFullError(oldbuf);
+      }
+
+      s = this.w - this.r; // do not rescan area we scanned before
+
+      // Buffer is not full.
+      try {
+        await this._fill();
+      } catch (err) {
+        err.partial = slice;
+        throw err;
+      }
+    }
+
+    // Handle last byte, if any.
+    // const i = slice.byteLength - 1;
+    // if (i >= 0) {
+    //   this.lastByte = slice[i];
+    //   this.lastCharSize = -1
+    // }
+
+    return slice;
+  }
+
+  /** `peek()` returns the next `n` bytes without advancing the reader. The
+   * bytes stop being valid at the next read call.
+   *
+   * When the end of the underlying stream is reached, but there are unread
+   * bytes left in the buffer, those bytes are returned. If there are no bytes
+   * left in the buffer, it returns `null`.
+   *
+   * If an error is encountered before `n` bytes are available, `peek()` throws
+   * an error with the `partial` property set to a slice of the buffer that
+   * contains the bytes that were available before the error occurred.
+   */
+  async peek(n: number): Promise<Uint8Array | null> {
+    if (n < 0) {
+      throw Error("negative count");
+    }
+
+    let avail = this.w - this.r;
+    while (avail < n && avail < this.buf.byteLength && !this.eof) {
+      try {
+        await this._fill();
+      } catch (err) {
+        err.partial = this.buf.subarray(this.r, this.w);
+        throw err;
+      }
+      avail = this.w - this.r;
+    }
+
+    if (avail === 0 && this.eof) {
+      return null;
+    } else if (avail < n && this.eof) {
+      return this.buf.subarray(this.r, this.r + avail);
+    } else if (avail < n) {
+      throw new BufferFullError(this.buf.subarray(this.r, this.w));
+    }
+
+    return this.buf.subarray(this.r, this.r + n);
+  }
+}
+
+abstract class AbstractBufBase {
+  buf!: Uint8Array;
+  usedBufferBytes = 0;
+  err: Error | null = null;
+
+  /** Size returns the size of the underlying buffer in bytes. */
+  size(): number {
+    return this.buf.byteLength;
+  }
+
+  /** Returns how many bytes are unused in the buffer. */
+  available(): number {
+    return this.buf.byteLength - this.usedBufferBytes;
+  }
+
+  /** buffered returns the number of bytes that have been written into the
+   * current buffer.
+   */
+  buffered(): number {
+    return this.usedBufferBytes;
+  }
+}
+
+/** BufWriter implements buffering for an deno.Writer object.
+ * If an error occurs writing to a Writer, no more data will be
+ * accepted and all subsequent writes, and flush(), will return the error.
+ * After all data has been written, the client should call the
+ * flush() method to guarantee all data has been forwarded to
+ * the underlying deno.Writer.
+ */
+export class BufWriter extends AbstractBufBase implements Writer {
+  /** return new BufWriter unless writer is BufWriter */
+  static create(writer: Writer, size: number = DEFAULT_BUF_SIZE): BufWriter {
+    return writer instanceof BufWriter ? writer : new BufWriter(writer, size);
+  }
+
+  constructor(private writer: Writer, size: number = DEFAULT_BUF_SIZE) {
+    super();
+    if (size <= 0) {
+      size = DEFAULT_BUF_SIZE;
+    }
+    this.buf = new Uint8Array(size);
+  }
+
+  /** Discards any unflushed buffered data, clears any error, and
+   * resets buffer to write its output to w.
+   */
+  reset(w: Writer): void {
+    this.err = null;
+    this.usedBufferBytes = 0;
+    this.writer = w;
+  }
+
+  /** Flush writes any buffered data to the underlying io.Writer. */
+  async flush(): Promise<void> {
+    if (this.err !== null) throw this.err;
+    if (this.usedBufferBytes === 0) return;
+
+    try {
+      await writeAll(
+        this.writer,
+        this.buf.subarray(0, this.usedBufferBytes),
+      );
+    } catch (e) {
+      this.err = e;
+      throw e;
+    }
+
+    this.buf = new Uint8Array(this.buf.length);
+    this.usedBufferBytes = 0;
+  }
+
+  /** Writes the contents of `data` into the buffer.  If the contents won't fully
+   * fit into the buffer, those bytes that can are copied into the buffer, the
+   * buffer is the flushed to the writer and the remaining bytes are copied into
+   * the now empty buffer.
+   *
+   * @return the number of bytes written to the buffer.
+   */
+  async write(data: Uint8Array): Promise<number> {
+    if (this.err !== null) throw this.err;
+    if (data.length === 0) return 0;
+
+    let totalBytesWritten = 0;
+    let numBytesWritten = 0;
+    while (data.byteLength > this.available()) {
+      if (this.buffered() === 0) {
+        // Large write, empty buffer.
+        // Write directly from data to avoid copy.
+        try {
+          numBytesWritten = await this.writer.write(data);
+        } catch (e) {
+          this.err = e;
+          throw e;
+        }
+      } else {
+        numBytesWritten = copy(data, this.buf, this.usedBufferBytes);
+        this.usedBufferBytes += numBytesWritten;
+        await this.flush();
+      }
+      totalBytesWritten += numBytesWritten;
+      data = data.subarray(numBytesWritten);
+    }
+
+    numBytesWritten = copy(data, this.buf, this.usedBufferBytes);
+    this.usedBufferBytes += numBytesWritten;
+    totalBytesWritten += numBytesWritten;
+    return totalBytesWritten;
+  }
+}
+
+/** BufWriterSync implements buffering for a deno.WriterSync object.
+ * If an error occurs writing to a WriterSync, no more data will be
+ * accepted and all subsequent writes, and flush(), will return the error.
+ * After all data has been written, the client should call the
+ * flush() method to guarantee all data has been forwarded to
+ * the underlying deno.WriterSync.
+ */
+export class BufWriterSync extends AbstractBufBase implements WriterSync {
+  /** return new BufWriterSync unless writer is BufWriterSync */
+  static create(
+    writer: WriterSync,
+    size: number = DEFAULT_BUF_SIZE,
+  ): BufWriterSync {
+    return writer instanceof BufWriterSync
+      ? writer
+      : new BufWriterSync(writer, size);
+  }
+
+  constructor(private writer: WriterSync, size: number = DEFAULT_BUF_SIZE) {
+    super();
+    if (size <= 0) {
+      size = DEFAULT_BUF_SIZE;
+    }
+    this.buf = new Uint8Array(size);
+  }
+
+  /** Discards any unflushed buffered data, clears any error, and
+   * resets buffer to write its output to w.
+   */
+  reset(w: WriterSync): void {
+    this.err = null;
+    this.usedBufferBytes = 0;
+    this.writer = w;
+  }
+
+  /** Flush writes any buffered data to the underlying io.WriterSync. */
+  flush(): void {
+    if (this.err !== null) throw this.err;
+    if (this.usedBufferBytes === 0) return;
+
+    try {
+      writeAllSync(
+        this.writer,
+        this.buf.subarray(0, this.usedBufferBytes),
+      );
+    } catch (e) {
+      this.err = e;
+      throw e;
+    }
+
+    this.buf = new Uint8Array(this.buf.length);
+    this.usedBufferBytes = 0;
+  }
+
+  /** Writes the contents of `data` into the buffer.  If the contents won't fully
+   * fit into the buffer, those bytes that can are copied into the buffer, the
+   * buffer is the flushed to the writer and the remaining bytes are copied into
+   * the now empty buffer.
+   *
+   * @return the number of bytes written to the buffer.
+   */
+  writeSync(data: Uint8Array): number {
+    if (this.err !== null) throw this.err;
+    if (data.length === 0) return 0;
+
+    let totalBytesWritten = 0;
+    let numBytesWritten = 0;
+    while (data.byteLength > this.available()) {
+      if (this.buffered() === 0) {
+        // Large write, empty buffer.
+        // Write directly from data to avoid copy.
+        try {
+          numBytesWritten = this.writer.writeSync(data);
+        } catch (e) {
+          this.err = e;
+          throw e;
+        }
+      } else {
+        numBytesWritten = copy(data, this.buf, this.usedBufferBytes);
+        this.usedBufferBytes += numBytesWritten;
+        this.flush();
+      }
+      totalBytesWritten += numBytesWritten;
+      data = data.subarray(numBytesWritten);
+    }
+
+    numBytesWritten = copy(data, this.buf, this.usedBufferBytes);
+    this.usedBufferBytes += numBytesWritten;
+    totalBytesWritten += numBytesWritten;
+    return totalBytesWritten;
+  }
+}
+
+/** Generate longest proper prefix which is also suffix array. */
+function createLPS(pat: Uint8Array): Uint8Array {
+  const lps = new Uint8Array(pat.length);
+  lps[0] = 0;
+  let prefixEnd = 0;
+  let i = 1;
+  while (i < lps.length) {
+    if (pat[i] == pat[prefixEnd]) {
+      prefixEnd++;
+      lps[i] = prefixEnd;
+      i++;
+    } else if (prefixEnd === 0) {
+      lps[i] = 0;
+      i++;
+    } else {
+      prefixEnd = pat[prefixEnd - 1];
+    }
+  }
+  return lps;
+}
+
+/** Read delimited bytes from a Reader. */
+export async function* readDelim(
+  reader: Reader,
+  delim: Uint8Array,
+): AsyncIterableIterator<Uint8Array> {
+  // Avoid unicode problems
+  const delimLen = delim.length;
+  const delimLPS = createLPS(delim);
+
+  let inputBuffer = new Buffer();
+  const inspectArr = new Uint8Array(Math.max(1024, delimLen + 1));
+
+  // Modified KMP
+  let inspectIndex = 0;
+  let matchIndex = 0;
+  while (true) {
+    const result = await reader.read(inspectArr);
+    if (result === null) {
+      // Yield last chunk.
+      yield inputBuffer.bytes();
+      return;
+    }
+    if ((result as number) < 0) {
+      // Discard all remaining and silently fail.
+      return;
+    }
+    const sliceRead = inspectArr.subarray(0, result as number);
+    await writeAll(inputBuffer, sliceRead);
+
+    let sliceToProcess = inputBuffer.bytes();
+    while (inspectIndex < sliceToProcess.length) {
+      if (sliceToProcess[inspectIndex] === delim[matchIndex]) {
+        inspectIndex++;
+        matchIndex++;
+        if (matchIndex === delimLen) {
+          // Full match
+          const matchEnd = inspectIndex - delimLen;
+          const readyBytes = sliceToProcess.subarray(0, matchEnd);
+          // Copy
+          const pendingBytes = sliceToProcess.slice(inspectIndex);
+          yield readyBytes;
+          // Reset match, different from KMP.
+          sliceToProcess = pendingBytes;
+          inspectIndex = 0;
+          matchIndex = 0;
+        }
+      } else {
+        if (matchIndex === 0) {
+          inspectIndex++;
+        } else {
+          matchIndex = delimLPS[matchIndex - 1];
+        }
+      }
+    }
+    // Keep inspectIndex and matchIndex.
+    inputBuffer = new Buffer(sliceToProcess);
+  }
+}
+
+/** Read delimited strings from a Reader. */
+export async function* readStringDelim(
+  reader: Reader,
+  delim: string,
+): AsyncIterableIterator<string> {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  for await (const chunk of readDelim(reader, encoder.encode(delim))) {
+    yield decoder.decode(chunk);
+  }
+}
+
+/** Read strings line-by-line from a Reader. */
+export async function* readLines(
+  reader: Reader,
+): AsyncIterableIterator<string> {
+  for await (let chunk of readStringDelim(reader, "\n")) {
+    // Finding a CR at the end of the line is evidence of a
+    // "\r\n" at the end of the line. The "\r" part should be
+    // removed too.
+    if (chunk.endsWith("\r")) {
+      chunk = chunk.slice(0, -1);
+    }
+    yield chunk;
+  }
+}

--- a/vendor/deno.land/std@0.92.0/io/readers.ts
+++ b/vendor/deno.land/std@0.92.0/io/readers.ts
@@ -1,0 +1,62 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+// Based on https://github.com/golang/go/blob/0452f9460f50f0f0aba18df43dc2b31906fb66cc/src/io/io.go
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import { Buffer } from "./buffer.ts";
+
+/** Reader utility for strings */
+export class StringReader extends Buffer {
+  constructor(s: string) {
+    super(new TextEncoder().encode(s).buffer);
+  }
+}
+
+/** Reader utility for combining multiple readers */
+export class MultiReader implements Deno.Reader {
+  private readonly readers: Deno.Reader[];
+  private currentIndex = 0;
+
+  constructor(...readers: Deno.Reader[]) {
+    this.readers = readers;
+  }
+
+  async read(p: Uint8Array): Promise<number | null> {
+    const r = this.readers[this.currentIndex];
+    if (!r) return null;
+    const result = await r.read(p);
+    if (result === null) {
+      this.currentIndex++;
+      return 0;
+    }
+    return result;
+  }
+}
+
+/**
+ * A `LimitedReader` reads from `reader` but limits the amount of data returned to just `limit` bytes.
+ * Each call to `read` updates `limit` to reflect the new amount remaining.
+ * `read` returns `null` when `limit` <= `0` or
+ * when the underlying `reader` returns `null`.
+ */
+export class LimitedReader implements Deno.Reader {
+  constructor(public reader: Deno.Reader, public limit: number) {}
+
+  async read(p: Uint8Array): Promise<number | null> {
+    if (this.limit <= 0) {
+      return null;
+    }
+
+    if (p.length > this.limit) {
+      p = p.subarray(0, this.limit);
+    }
+    const n = await this.reader.read(p);
+    if (n == null) {
+      return null;
+    }
+
+    this.limit -= n;
+    return n;
+  }
+}

--- a/vendor/deno.land/std@0.92.0/io/util.ts
+++ b/vendor/deno.land/std@0.92.0/io/util.ts
@@ -1,0 +1,107 @@
+import { Buffer } from "./buffer.ts";
+
+/** Read Reader `r` until EOF (`null`) and resolve to the content as
+ * Uint8Array`.
+ *
+ * ```ts
+ * 
+ * // Example from stdin
+ * const stdinContent = await readAll(Deno.stdin);
+ *
+ * // Example from file
+ * const file = await Deno.open("my_file.txt", {read: true});
+ * const myFileContent = await readAll(file);
+ * Deno.close(file.rid);
+ *
+ * // Example from buffer
+ * const myData = new Uint8Array(100);
+ * // ... fill myData array with data
+ * const reader = new Buffer(myData.buffer as ArrayBuffer);
+ * const bufferContent = await readAll(reader);
+ * ```
+ */
+export async function readAll(r: Deno.Reader): Promise<Uint8Array> {
+  const buf = new Buffer();
+  await buf.readFrom(r);
+  return buf.bytes();
+}
+
+/** Synchronously reads Reader `r` until EOF (`null`) and returns the content
+ * as `Uint8Array`.
+ *
+ * ```ts
+ * // Example from stdin
+ * const stdinContent = readAllSync(Deno.stdin);
+ *
+ * // Example from file
+ * const file = Deno.openSync("my_file.txt", {read: true});
+ * const myFileContent = readAllSync(file);
+ * Deno.close(file.rid);
+ *
+ * // Example from buffer
+ * const myData = new Uint8Array(100);
+ * // ... fill myData array with data
+ * const reader = new Buffer(myData.buffer as ArrayBuffer);
+ * const bufferContent = readAllSync(reader);
+ * ```
+ */
+export function readAllSync(r: Deno.ReaderSync): Uint8Array {
+  const buf = new Buffer();
+  buf.readFromSync(r);
+  return buf.bytes();
+}
+
+/** Write all the content of the array buffer (`arr`) to the writer (`w`).
+ *
+ * ```ts
+ * // Example writing to stdout
+ * const contentBytes = new TextEncoder().encode("Hello World");
+ * await writeAll(Deno.stdout, contentBytes);
+ *
+ * // Example writing to file
+ * const contentBytes = new TextEncoder().encode("Hello World");
+ * const file = await Deno.open('test.file', {write: true});
+ * await writeAll(file, contentBytes);
+ * Deno.close(file.rid);
+ *
+ * // Example writing to buffer
+ * const contentBytes = new TextEncoder().encode("Hello World");
+ * const writer = new Buffer();
+ * await writeAll(writer, contentBytes);
+ * console.log(writer.bytes().length);  // 11
+ * ```
+ */
+export async function writeAll(w: Deno.Writer, arr: Uint8Array): Promise<void> {
+  let nwritten = 0;
+  while (nwritten < arr.length) {
+    nwritten += await w.write(arr.subarray(nwritten));
+  }
+}
+
+/** Synchronously write all the content of the array buffer (`arr`) to the
+ * writer (`w`).
+ *
+ * ```ts
+ * // Example writing to stdout
+ * const contentBytes = new TextEncoder().encode("Hello World");
+ * writeAllSync(Deno.stdout, contentBytes);
+ *
+ * // Example writing to file
+ * const contentBytes = new TextEncoder().encode("Hello World");
+ * const file = Deno.openSync('test.file', {write: true});
+ * writeAllSync(file, contentBytes);
+ * Deno.close(file.rid);
+ *
+ * // Example writing to buffer
+ * const contentBytes = new TextEncoder().encode("Hello World");
+ * const writer = new Buffer();
+ * writeAllSync(writer, contentBytes);
+ * console.log(writer.bytes().length);  // 11
+ * ```
+ */
+export function writeAllSync(w: Deno.WriterSync, arr: Uint8Array): void {
+  let nwritten = 0;
+  while (nwritten < arr.length) {
+    nwritten += w.writeSync(arr.subarray(nwritten));
+  }
+}

--- a/vendor/deno.land/std@0.92.0/textproto/mod.ts
+++ b/vendor/deno.land/std@0.92.0/textproto/mod.ts
@@ -1,0 +1,164 @@
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
+// Based on https://github.com/golang/go/tree/master/src/net/textproto
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import type { BufReader } from "../io/bufio.ts";
+import { concat } from "../bytes/mod.ts";
+
+const decoder = new TextDecoder();
+
+// FROM https://github.com/denoland/deno/blob/b34628a26ab0187a827aa4ebe256e23178e25d39/cli/js/web/headers.ts#L9
+const invalidHeaderCharRegex = /[^\t\x20-\x7e\x80-\xff]/g;
+
+function str(buf: Uint8Array | null | undefined): string {
+  if (buf == null) {
+    return "";
+  } else {
+    return decoder.decode(buf);
+  }
+}
+
+function charCode(s: string): number {
+  return s.charCodeAt(0);
+}
+
+export class TextProtoReader {
+  constructor(readonly r: BufReader) {}
+
+  /** readLine() reads a single line from the TextProtoReader,
+   * eliding the final \n or \r\n from the returned string.
+   */
+  async readLine(): Promise<string | null> {
+    const s = await this.readLineSlice();
+    if (s === null) return null;
+    return str(s);
+  }
+
+  /** ReadMIMEHeader reads a MIME-style header from r.
+   * The header is a sequence of possibly continued Key: Value lines
+   * ending in a blank line.
+   * The returned map m maps CanonicalMIMEHeaderKey(key) to a
+   * sequence of values in the same order encountered in the input.
+   *
+   * For example, consider this input:
+   *
+   *	My-Key: Value 1
+   *	Long-Key: Even
+   *	       Longer Value
+   *	My-Key: Value 2
+   *
+   * Given that input, ReadMIMEHeader returns the map:
+   *
+   *	map[string][]string{
+   *		"My-Key": {"Value 1", "Value 2"},
+   *		"Long-Key": {"Even Longer Value"},
+   *	}
+   */
+  async readMIMEHeader(): Promise<Headers | null> {
+    const m = new Headers();
+    let line: Uint8Array | undefined;
+
+    // The first line cannot start with a leading space.
+    let buf = await this.r.peek(1);
+    if (buf === null) {
+      return null;
+    } else if (buf[0] == charCode(" ") || buf[0] == charCode("\t")) {
+      line = (await this.readLineSlice()) as Uint8Array;
+    }
+
+    buf = await this.r.peek(1);
+    if (buf === null) {
+      throw new Deno.errors.UnexpectedEof();
+    } else if (buf[0] == charCode(" ") || buf[0] == charCode("\t")) {
+      throw new Deno.errors.InvalidData(
+        `malformed MIME header initial line: ${str(line)}`,
+      );
+    }
+
+    while (true) {
+      const kv = await this.readLineSlice(); // readContinuedLineSlice
+      if (kv === null) throw new Deno.errors.UnexpectedEof();
+      if (kv.byteLength === 0) return m;
+
+      // Key ends at first colon
+      let i = kv.indexOf(charCode(":"));
+      if (i < 0) {
+        throw new Deno.errors.InvalidData(
+          `malformed MIME header line: ${str(kv)}`,
+        );
+      }
+
+      //let key = canonicalMIMEHeaderKey(kv.subarray(0, endKey));
+      const key = str(kv.subarray(0, i));
+
+      // As per RFC 7230 field-name is a token,
+      // tokens consist of one or more chars.
+      // We could throw `Deno.errors.InvalidData` here,
+      // but better to be liberal in what we
+      // accept, so if we get an empty key, skip it.
+      if (key == "") {
+        continue;
+      }
+
+      // Skip initial spaces in value.
+      i++; // skip colon
+      while (
+        i < kv.byteLength &&
+        (kv[i] == charCode(" ") || kv[i] == charCode("\t"))
+      ) {
+        i++;
+      }
+      const value = str(kv.subarray(i)).replace(
+        invalidHeaderCharRegex,
+        encodeURI,
+      );
+
+      // In case of invalid header we swallow the error
+      // example: "Audio Mode" => invalid due to space in the key
+      try {
+        m.append(key, value);
+      } catch {
+        // Pass
+      }
+    }
+  }
+
+  async readLineSlice(): Promise<Uint8Array | null> {
+    // this.closeDot();
+    let line: Uint8Array | undefined;
+    while (true) {
+      const r = await this.r.readLine();
+      if (r === null) return null;
+      const { line: l, more } = r;
+
+      // Avoid the copy if the first call produced a full line.
+      if (!line && !more) {
+        // TODO(ry):
+        // This skipSpace() is definitely misplaced, but I don't know where it
+        // comes from nor how to fix it.
+        if (this.skipSpace(l) === 0) {
+          return new Uint8Array(0);
+        }
+        return l;
+      }
+      line = line ? concat(line, l) : l;
+      if (!more) {
+        break;
+      }
+    }
+    return line;
+  }
+
+  skipSpace(l: Uint8Array): number {
+    let n = 0;
+    for (let i = 0; i < l.length; i++) {
+      if (l[i] === charCode(" ") || l[i] === charCode("\t")) {
+        continue;
+      }
+      n++;
+    }
+    return n;
+  }
+}

--- a/vendor/deno.land/x/flat@0.0.15/src/csv.ts
+++ b/vendor/deno.land/x/flat@0.0.15/src/csv.ts
@@ -1,0 +1,29 @@
+import { parse, ParseOptions } from 'https://deno.land/std@0.92.0/encoding/csv.ts'
+import { DataItem, stringify } from 'https://deno.land/std@0.92.0/encoding/csv.ts';
+
+export async function readCSV(path: string, options?: ParseOptions): Promise<Record<string, unknown>[]> {
+    if (!options || !('skipFirstRow' in options)) {
+        // to force library to be consistent and return an array of objects
+        options = { 
+            ...options,
+            skipFirstRow: true
+        }
+    }
+
+    const raw = await Deno.readTextFile(path)
+    const content = await parse(raw, options)
+    return content as Record<string, unknown>[]
+}
+
+export async function writeCSV(path: string, data: Record<string, unknown>[] | string, options?: Deno.WriteFileOptions) {
+    if (typeof data === 'string') {
+        await Deno.writeTextFile(path, data, options);
+        return
+    }
+
+    const headers = Object.keys(data[0])
+    // we have to stringify the data with a row header
+    const dataString = await stringify(data as DataItem[], headers)
+
+    await Deno.writeTextFile(path, dataString, options);
+}


### PR DESCRIPTION
Ref. #7 
The daily data Action was failing because it uses `flat`, which is unmaintained (last release 2023), runs on the node16 runner GitHub has removed support for, and hardcoded a Deno command we couldn't give Deno 2's required `--allow-import` flag - which is what broke the runs. The ticket also asked to update `checkout`, `flat`,
and `deno` to current versions.

### Changes
- Replaced the `flat` action in `flat.yml` with explicit steps: curl download -> `deno run` cleanup -> commit if changed.
- Bumped `checkout` v4.1.7 -> v6, `setup-deno` @main -> @v2, Deno v1.x -> v2.x.
- Updated the import to be explicit `postprocess.ts`
- Vendored the `flat` library, cleanup runs offline
- Added `vendor-flat.sh` to re-vendor or change the library version in future.

### Testing
- CI on this branch
- For local testing of the library run and offline cleanup:
```
brew install deno
chmod +x vendor-flat.sh
./vendor-flat.sh
curl -fsSL -o tribal-leaders.csv "https://services1.arcgis.com/UxqqIfhng71wUT9x/arcgis/rest/services/TribalLeadership_Directory/FeatureServer/replicafilescache/TribalLeadership_Directory_-8807089639668789909.csv"
deno run --allow-read --allow-write --cached-only postprocess.ts tribal-leaders.csv
git checkout -- tribal-leaders.csv
```
